### PR TITLE
Analyze prospective version bumps

### DIFF
--- a/src/RegistryCompatTools.jl
+++ b/src/RegistryCompatTools.jl
@@ -71,7 +71,7 @@ function held_back_packages(; newversions=Dict{UUID,VersionNumber}())
         versions = load_versions(pkgpath)
         nv = get_newversion(newversions, uuid, name, nothing)
         if nv !== nothing
-            versions[nv] = Base.SHA1(ntuple(i->0x00, sizeof(Base.SHA1)))
+            versions[nv] = Base.SHA1(fill(0x00, 20))
         end
         max_version = maximum(keys(versions))
         packages[UUID(uuid)] = Package(name, pkgpath, max_version)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,3 +4,5 @@ using Test
 
 @test held_back_packages() isa Dict
 @test held_back_by("Requires") isa Vector{String}
+# The following test assumes that at least one of the dependents of ColorTypes is compatible with the latest version
+@test length(held_back_by("ColorTypes", typemax(VersionNumber))) > length(held_back_by("ColorTypes"))


### PR DESCRIPTION
If you're thinking about bumping the version number of a package,
sometimes it's nice to know in advance what [compat] you'll have to bump.